### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ function createRavenMiddleware(Raven, options = {}) {
 
     Raven.setDataCallback((data, original) => {
       data.extra.lastAction = actionTransformer(lastAction);
-      data.extra.state = stateTransformer(store.getState());
       return original ? original(data) : data;
     });
 


### PR DESCRIPTION
Raven blows up if there are state objects with recursive elements inside state (i.e. callbacks)

Disable stuff for now.