### PR TITLE
Add filterBreadcrumbActions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,15 @@ Each breadcrumb is assigned a category. By default all action breadcrumbs are
 given the category `"redux-action"`. If you would prefer a different category
 name, specify it here.
 
-#### `ignoreActions` _(Array)_
+#### `filterBreadcrumbActions` _(Function)_
 
-Default: `[]`
+Default: `action => true` _(Function)_
 
 If your app has certain actions that you do not want to send to Sentry, pass
-an array of the action types in this option. They will not be logged.
+a filter function in this option. If the filter returns `true`, the action
+will be added as a breadcrumb, otherwise the action will be ignored.
+Note: even when the action has been filtered out, it may still be sent to
+Sentry as part of the extra data, if it was the last action before an error.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This library makes, what I think are, a few improvements over
    `<script>` tag.
 2. Adds your state and last action as context to _all_ errors, not just reducer
    exceptions.
+3. Allows filtering action breadcrumbs before sending to Sentry
 
 ## API: `createRavenMiddleware(Raven, [options])`
 
@@ -133,8 +134,8 @@ name, specify it here.
 Default: `action => true` _(Function)_
 
 If your app has certain actions that you do not want to send to Sentry, pass
-a filter function in this option. If the filter returns `true`, the action
-will be added as a breadcrumb, otherwise the action will be ignored.
+a filter function in this option. If the filter returns a truthy value, the
+action will be added as a breadcrumb, otherwise the action will be ignored.
 Note: even when the action has been filtered out, it may still be sent to
 Sentry as part of the extra data, if it was the last action before an error.
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ Each breadcrumb is assigned a category. By default all action breadcrumbs are
 given the category `"redux-action"`. If you would prefer a different category
 name, specify it here.
 
+#### `ignoreActions` _(Array)_
+
+Default: `[]`
+
+If your app has certain actions that you do not want to send to Sentry, pass
+an array of the action types in this option. They will not be logged.
+
 ## Changelog
 
 ### 1.0.0

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const identity = x => x;
 const getUndefined = () => {};
+const filter = () => true;
 function createRavenMiddleware(Raven, options = {}) {
   // TODO: Validate options.
   const {
@@ -7,7 +8,7 @@ function createRavenMiddleware(Raven, options = {}) {
     actionTransformer = identity,
     stateTransformer = identity,
     breadcrumbCategory = "redux-action",
-    ignoreActions = []
+    filterBreadcrumbActions = filter
   } = options;
 
   return store => {
@@ -22,13 +23,13 @@ function createRavenMiddleware(Raven, options = {}) {
     return next => action => {
       // Log the action taken to Raven so that we have narrative context in our
       // error report.
-      if (ignoreActions.indexOf(action.type) > -1) return next(action);
-
-      Raven.captureBreadcrumb({
-        category: breadcrumbCategory,
-        message: action.type,
-        data: breadcrumbDataFromAction(action)
-      });
+      if (filterBreadcrumbActions(action) === true) {
+        Raven.captureBreadcrumb({
+          category: breadcrumbCategory,
+          message: action.type,
+          data: breadcrumbDataFromAction(action)
+        });
+      }
 
       lastAction = action;
       return next(action);

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function createRavenMiddleware(Raven, options = {}) {
     return next => action => {
       // Log the action taken to Raven so that we have narrative context in our
       // error report.
-      if (filterBreadcrumbActions(action) === true) {
+      if (filterBreadcrumbActions(action)) {
         Raven.captureBreadcrumb({
           category: breadcrumbCategory,
           message: action.type,

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ function createRavenMiddleware(Raven, options = {}) {
     breadcrumbDataFromAction = getUndefined,
     actionTransformer = identity,
     stateTransformer = identity,
-    breadcrumbCategory = "redux-action"
+    breadcrumbCategory = "redux-action",
+    ignoreActions = []
   } = options;
 
   return store => {
@@ -21,6 +22,8 @@ function createRavenMiddleware(Raven, options = {}) {
     return next => action => {
       // Log the action taken to Raven so that we have narrative context in our
       // error report.
+      if (ignoreActions.indexOf(action.type) > -1) return next(action);
+
       Raven.captureBreadcrumb({
         category: breadcrumbCategory,
         message: action.type,

--- a/index.test.js
+++ b/index.test.js
@@ -201,19 +201,21 @@ describe("raven-for-redux", function() {
     it("filters actions for breadcrumbs", function() {
       context.store.dispatch({ type: "INCREMENT" });
       context.store.dispatch({ type: "UNINTERESTING_ACTION" });
-      context.store.dispatch({ type: "INCREMENT" });
-      context.store.dispatch({ type: "UNINTERESTING_ACTION" });
       context.store.dispatch({ type: "UNINTERESTING_ACTION" });
       Raven.captureMessage("report!");
 
       expect(context.mockTransport).toHaveBeenCalledTimes(1);
-      const {
-        extra,
-        breadcrumbs
-      } = context.mockTransport.mock.calls[0][0].data;
+      const { breadcrumbs } = context.mockTransport.mock.calls[0][0].data;
+      expect(breadcrumbs.values.length).toBe(1);
+    });
+    it("sends action with data.extra even if it was filtered", function() {
+      context.store.dispatch({ type: "UNINTERESTING_ACTION" });
+      Raven.captureMessage("report!");
+
+      expect(context.mockTransport).toHaveBeenCalledTimes(1);
+      const { extra } = context.mockTransport.mock.calls[0][0].data;
       // Even though the action isn't added to breadcrumbs, it should be sent with extra data
       expect(extra.lastAction).toEqual({ type: "UNINTERESTING_ACTION" });
-      expect(breadcrumbs.values.length).toBe(2);
     });
   });
 });

--- a/index.test.js
+++ b/index.test.js
@@ -181,20 +181,22 @@ describe("raven-for-redux", function() {
     });
   });
 
-  describe("with ignoreActions option enabled", function() {
+  describe("with filterBreadcrumbActions option enabled", function() {
     beforeEach(function() {
-      context.ignoreActions = ["UNINTERESTING_ACTION"];
+      context.filterBreadcrumbActions = action => {
+        return action.type === "INCREMENT";
+      };
 
       context.store = createStore(
         reducer,
         applyMiddleware(
           createRavenMiddleware(Raven, {
-            ignoreActions: context.ignoreActions
+            filterBreadcrumbActions: context.filterBreadcrumbActions
           })
         )
       );
     });
-    it("ignores actions specified in config", function() {
+    it("filters actions for breadcrumbs", function() {
       context.store.dispatch({ type: "INCREMENT" });
       context.store.dispatch({ type: "UNINTERESTING_ACTION" });
       context.store.dispatch({ type: "INCREMENT" });
@@ -206,7 +208,8 @@ describe("raven-for-redux", function() {
         extra,
         breadcrumbs
       } = context.mockTransport.mock.calls[0][0].data;
-      expect(extra.lastAction).toEqual({ type: "INCREMENT" });
+      // Even though the action isn't added to breadcrumbs, it should be sent with extra data
+      expect(extra.lastAction).toEqual({ type: "UNINTERESTING_ACTION" });
       expect(breadcrumbs.values.length).toBe(2);
     });
   });

--- a/index.test.js
+++ b/index.test.js
@@ -117,7 +117,9 @@ describe("raven-for-redux", function() {
       context.breadcrumbDataFromAction = jest.fn(action => ({
         extra: action.extra
       }));
-      context.ignoreActions = ["UNINTERESTING_ACTION"];
+      context.filterBreadcrumbActions = action => {
+        return action.type !== "UNINTERESTING_ACTION";
+      };
 
       context.store = createStore(
         reducer,
@@ -126,7 +128,7 @@ describe("raven-for-redux", function() {
             stateTransformer: context.stateTransformer,
             actionTransformer: context.actionTransformer,
             breadcrumbDataFromAction: context.breadcrumbDataFromAction,
-            ignoreActions: context.ignoreActions
+            filterBreadcrumbActions: context.filterBreadcrumbActions
           })
         )
       );
@@ -184,7 +186,7 @@ describe("raven-for-redux", function() {
   describe("with filterBreadcrumbActions option enabled", function() {
     beforeEach(function() {
       context.filterBreadcrumbActions = action => {
-        return action.type === "INCREMENT";
+        return action.type !== "UNINTERESTING_ACTION";
       };
 
       context.store = createStore(
@@ -200,6 +202,7 @@ describe("raven-for-redux", function() {
       context.store.dispatch({ type: "INCREMENT" });
       context.store.dispatch({ type: "UNINTERESTING_ACTION" });
       context.store.dispatch({ type: "INCREMENT" });
+      context.store.dispatch({ type: "UNINTERESTING_ACTION" });
       context.store.dispatch({ type: "UNINTERESTING_ACTION" });
       Raven.captureMessage("report!");
 


### PR DESCRIPTION
filterBreadcrumbActions is a function that returns `true` if an action should be added to the breadcrumbs.

The rationale for this is that some Redux apps use some actions internally to trigger state changes that are both prolific and not directly connected to user behavior. They can overwhelm the logs and have essentially no value for debugging purposes.