### PR TITLE
User context

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This library makes, what I think are, a few improvements over
 2. Adds your state and last action as context to _all_ errors, not just reducer
    exceptions.
 3. Allows filtering action breadcrumbs before sending to Sentry
+4. Allows you to define a user context mapping from the state
 
 ## API: `createRavenMiddleware(Raven, [options])`
 
@@ -141,6 +142,24 @@ Sentry as part of the extra data, if it was the last action before an error.
 
 This option was introduced in version 1.1.1.
 
+#### `getUserContext` _(Optional Function)_
+
+Signature: `state => userContext`
+
+The [user context] is an important part of the error report. This function
+allows you to define a mapping from the `state` to the user context. When
+`getUserContext` is spesified, the result of `getUserContext`
+will set the the user context before sending the error report.
+
+Be careful not to mutate your `state` within this function.
+
+If you have specified a [`dataCallback`] when you configured Raven, note that
+`getUserContext` will be applied _before_ your specified `dataCallback`.
+When a `getUserContext` function is given, it will override the user context
+set elsewhere.
+
+This option was introduced in version 1.X
+
 ## Changelog
 
 ### 1.1.1
@@ -168,6 +187,7 @@ This option was introduced in version 1.1.1.
 [Raven]: https://docs.sentry.io/clients/javascript/
 [Raven Breadcrumbs]: https://docs.sentry.io/clients/javascript/usage/#recording-breadcrumbs
 [Breadcrumb documentation]: https://docs.sentry.io/learn/breadcrumbs/
+[user context]: https://docs.sentry.io/learn/context/#capturing-the-user
 [`dataCallback`]: https://docs.sentry.io/clients/javascript/config/
 [#11]: https://github.com/captbaritone/raven-for-redux/pull/11
 [#8]: https://github.com/captbaritone/raven-for-redux/pull/8

--- a/index.js
+++ b/index.js
@@ -8,15 +8,20 @@ function createRavenMiddleware(Raven, options = {}) {
     actionTransformer = identity,
     stateTransformer = identity,
     breadcrumbCategory = "redux-action",
-    filterBreadcrumbActions = filter
+    filterBreadcrumbActions = filter,
+    getUserContext
   } = options;
 
   return store => {
     let lastAction;
 
     Raven.setDataCallback((data, original) => {
+      const state = store.getState();
       data.extra.lastAction = actionTransformer(lastAction);
-      data.extra.state = stateTransformer(store.getState());
+      data.extra.state = stateTransformer(state);
+      if (getUserContext) {
+        data.user = getUserContext(state);
+      }
       return original ? original(data) : data;
     });
 

--- a/index.test.js
+++ b/index.test.js
@@ -107,6 +107,17 @@ describe("raven-for-redux", () => {
       expect(extra.lastAction).toEqual({ type: "DOUBLE" });
       expect(extra.state).toEqual(4);
     });
+    it("preserves user context", () => {
+      const userData = { userId: 1, username: "captbaritone" };
+      Raven.setUserContext(userData);
+      expect(() => {
+        context.store.dispatch({ type: "THROW", extra: "BAR" });
+      }).toThrow();
+
+      expect(context.mockTransport.mock.calls[0][0].data.user).toEqual(
+        userData
+      );
+    });
   });
   describe("with all the options enabled", () => {
     beforeEach(() => {
@@ -114,6 +125,7 @@ describe("raven-for-redux", () => {
       context.actionTransformer = jest.fn(
         action => `transformed action ${action.type}`
       );
+      context.getUserContext = jest.fn(state => `user context ${state}`);
       context.breadcrumbDataFromAction = jest.fn(action => ({
         extra: action.extra
       }));
@@ -128,7 +140,8 @@ describe("raven-for-redux", () => {
             stateTransformer: context.stateTransformer,
             actionTransformer: context.actionTransformer,
             breadcrumbDataFromAction: context.breadcrumbDataFromAction,
-            filterBreadcrumbActions: context.filterBreadcrumbActions
+            filterBreadcrumbActions: context.filterBreadcrumbActions,
+            getUserContext: context.getUserContext
           })
         )
       );
@@ -170,7 +183,8 @@ describe("raven-for-redux", () => {
       expect(breadcrumbs.values[0].data).toMatchObject({ extra: "FOO" });
       expect(breadcrumbs.values[1].data).toMatchObject({ extra: "BAR" });
     });
-    it("preserves user context", () => {
+    it("transforms the user context on data callback", () => {
+      context.store.dispatch({ type: "INCREMENT", extra: "FOO" });
       const userData = { userId: 1, username: "captbaritone" };
       Raven.setUserContext(userData);
       expect(() => {
@@ -178,7 +192,7 @@ describe("raven-for-redux", () => {
       }).toThrow();
 
       expect(context.mockTransport.mock.calls[0][0].data.user).toEqual(
-        userData
+        "user context 1"
       );
     });
   });


### PR DESCRIPTION
Hi,

This adds a way to set the user context with a state transformer. Any thoughts about this? (the name of the new attr is kinda bad, i know). It would be nice to be able to set the user context in the same callback as the state, because most often it only depends on the state. Here is a simple example with https://github.com/reactjs/reselect, and a state transformed with https://github.com/paularmstrong/normalizr:

```jsx
import { createSelector } from 'reselect';
export const selectCurrentUser = createSelector(
  state => state.users.byId,
  state => state.auth.id,
  (usersById, userId) => usersById[userId]
);
[...]
createRavenMiddleware(Raven, {
            userContextStateTransformer: selectCurrentUser
})
```

I have also added a few more tests in the second commit (now all lines are covered). If this looks good, i can write documentation so we can get it merged.

Thanks for this project! We use it in https://github.com/webkom/lego-webapp, and it works like a charm.    :smile: We also use it for `raven` (the node version), but that version has a more limited API - eg.`setDataCallback` is not available. 