### PR TITLE
removed react-native example from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,31 +41,6 @@ export default createStore(
 );
 ```
 
-### React Native (with Sentry)
-
-```JavaScript
-// store.js
-
-import { createStore, applyMiddleware } from 'redux'
-import { Sentry } from 'react-native-sentry'
-import createRavenMiddleware from 'raven-for-redux'
-
-import { reducer } from './my_reducer'
-
-Sentry.config('YOUR_DSN').install()
-
-export default createStore(
-    reducer,
-    applyMiddleware(
-        // Middlewares, like `redux-thunk` that intercept or emit actions should
-        // precede `raven-for-redux`.
-        createRavenMiddleware(Sentry, {
-            // Optionally pass some options here.
-        })
-    )
-)
-```
-
 For a working example, see the [example](./example/) directory.
 
 ### TypeScript


### PR DESCRIPTION
- React native example not working correctly so is removed
- Creating new repository for working with sentry middleware + react native here: [sentry-for-redux](https://github.com/emmajam/sentry-for-redux) *note:* only has a readme, changes to come.