### PR TITLE
Tag Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ function createRavenMiddleware(Raven, options = {}) {
     stateTransformer = identity,
     breadcrumbCategory = "redux-action",
     filterBreadcrumbActions = filter,
-    getUserContext
+    getUserContext,
+    getTags
   } = options;
 
   return store => {
@@ -24,6 +25,9 @@ function createRavenMiddleware(Raven, options = {}) {
       data.extra = Object.assign(reduxExtra, data.extra);
       if (getUserContext) {
         data.user = getUserContext(state);
+      }
+      if (getTags) {
+        data.tags = getTags(state);
       }
       return original ? original(data) : data;
     });

--- a/index.test.js
+++ b/index.test.js
@@ -196,6 +196,7 @@ describe("raven-for-redux", () => {
         action => `transformed action ${action.type}`
       );
       context.getUserContext = jest.fn(state => `user context ${state.value}`);
+      context.getTags = jest.fn(state => `tags ${state.value}`);
       context.breadcrumbDataFromAction = jest.fn(action => ({
         extra: action.extra
       }));
@@ -211,7 +212,8 @@ describe("raven-for-redux", () => {
             actionTransformer: context.actionTransformer,
             breadcrumbDataFromAction: context.breadcrumbDataFromAction,
             filterBreadcrumbActions: context.filterBreadcrumbActions,
-            getUserContext: context.getUserContext
+            getUserContext: context.getUserContext,
+            getTags: context.getTags
           })
         )
       );
@@ -263,6 +265,16 @@ describe("raven-for-redux", () => {
 
       expect(context.mockTransport.mock.calls[0][0].data.user).toEqual(
         "user context 1"
+      );
+    });
+    it("transforms the tags on data callback", () => {
+      context.store.dispatch({ type: "INCREMENT", extra: "FOO" });
+      expect(() => {
+        context.store.dispatch({ type: "THROW", extra: "BAR" });
+      }).toThrow();
+      expect(context.mockTransport).toHaveBeenCalledTimes(1);
+      expect(context.mockTransport.mock.calls[0][0].data.tags).toEqual(
+        "tags 1"
       );
     });
   });


### PR DESCRIPTION
This adds support for tags:

```js
createRavenMiddleware(Raven, {
  getTags: () => ({foo: 'foo', bar: 'bar'})
})
```

Nothing crazy, it just adds a `tags` field to `data` (`data.tags = getTags(state)`)

Screenshot from running this example:

![screen shot 2018-04-04 at 4 44 34 pm](https://user-images.githubusercontent.com/656630/38333760-80f64216-3827-11e8-9f3d-6bbf1ec74606.png)
