### PR TITLE
User defined Extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ within this function.
 
 This option was introduced in version 1.3.1.
 
+#### `getExtra` _(Optional Function)_
+
+Signature: `state => extra`
+
+Raven allows you to associate [extra] information with each report.
+By default, `raven-for-redux` will provide the state and the last action
+as extra information. `getExtra` allows you to define any additional
+information, in the form of an object, to send with the crash reports.
+
 ## Changelog
 
 ### 1.3.1
@@ -224,6 +233,7 @@ This option was introduced in version 1.3.1.
 [user context]: https://docs.sentry.io/learn/context/#capturing-the-user
 [`dataCallback`]: https://docs.sentry.io/clients/javascript/config/
 [tags]: https://docs.sentry.io/learn/context/#tagging-events
+[extra]: https://docs.sentry.io/learn/context/#extra-context
 [#11]: https://github.com/captbaritone/raven-for-redux/pull/11
 [#8]: https://github.com/captbaritone/raven-for-redux/pull/8
 [1def9a7]: https://github.com/captbaritone/raven-for-redux/commit/1def9a747d7b711ad93da531b8ff9d128c352b45

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function createRavenMiddleware(Raven, options = {}) {
     stateTransformer = identity,
     breadcrumbCategory = "redux-action",
     filterBreadcrumbActions = filter,
+    getExtra = getUndefined,
     getUserContext,
     getTags
   } = options;
@@ -22,7 +23,7 @@ function createRavenMiddleware(Raven, options = {}) {
         lastAction: actionTransformer(lastAction),
         state: stateTransformer(state)
       };
-      data.extra = Object.assign(reduxExtra, data.extra);
+      data.extra = Object.assign(reduxExtra, data.extra, getExtra(state));
       if (getUserContext) {
         data.user = getUserContext(state);
       }

--- a/index.test.js
+++ b/index.test.js
@@ -197,6 +197,9 @@ describe("raven-for-redux", () => {
       );
       context.getUserContext = jest.fn(state => `user context ${state.value}`);
       context.getTags = jest.fn(state => `tags ${state.value}`);
+      context.getExtra = jest.fn(state => ({
+        extra: `extra ${state.value}`
+      }));
       context.breadcrumbDataFromAction = jest.fn(action => ({
         extra: action.extra
       }));
@@ -212,6 +215,7 @@ describe("raven-for-redux", () => {
             actionTransformer: context.actionTransformer,
             breadcrumbDataFromAction: context.breadcrumbDataFromAction,
             filterBreadcrumbActions: context.filterBreadcrumbActions,
+            getExtra: context.getExtra,
             getUserContext: context.getUserContext,
             getTags: context.getTags
           })
@@ -275,6 +279,16 @@ describe("raven-for-redux", () => {
       expect(context.mockTransport).toHaveBeenCalledTimes(1);
       expect(context.mockTransport.mock.calls[0][0].data.tags).toEqual(
         "tags 1"
+      );
+    });
+    it("transforms user defined extras on data callback", () => {
+      context.store.dispatch({ type: "INCREMENT", extra: "FOO" });
+      expect(() => {
+        context.store.dispatch({ type: "THROW", extra: "BAR" });
+      }).toThrow();
+      expect(context.mockTransport).toHaveBeenCalledTimes(1);
+      expect(context.mockTransport.mock.calls[0][0].data.extra.extra).toEqual(
+        "extra 1"
       );
     });
   });


### PR DESCRIPTION
This expands the interface to allow users to attach additional `extra` information.

```js
createRavenMiddleware(Raven, {
  getExtra: state => ({
    foo: 'bar',
    bar: someCalculatedValue(state)
  })
})
```

Example

![screen shot 2018-04-10 at 10 35 50 am](https://user-images.githubusercontent.com/656630/38563476-fb59a5de-3caa-11e8-9227-4d2de5be0a51.png)
