### PR TITLE
If Sentry responds with 413 request too large, try to send the exception again without any state

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
     ],
     "rules": {
         "prettier/prettier": "error",
-        "prefer-arrow-callback": "error"
+        "prefer-arrow-callback": "error",
+        "prefer-reflect": "off",
     },
     "parserOptions": {
         "ecmaVersion": 8,

--- a/index.js
+++ b/index.js
@@ -32,6 +32,50 @@ function createRavenMiddleware(Raven, options = {}) {
       return original ? original(data) : data;
     });
 
+    const retryCaptureWithoutReduxState = captureFn => {
+      Raven.setDataCallback((data, originalCallback) => {
+        Raven.setDataCallback(originalCallback);
+        const reduxExtra = {
+          lastAction: actionTransformer(lastAction),
+          state: "Failed to submit state to Sentry: 413 request too large."
+        };
+        data.extra = Object.assign(reduxExtra, data.extra);
+        data.breadcrumbs.values = [];
+        return data;
+      });
+      // Raven has an internal check for duplicate errors that we need to disable.
+      const originalAllowDuplicates = Raven._globalOptions.allowDuplicates;
+      Raven._globalOptions.allowDuplicates = true;
+      captureFn();
+      Raven._globalOptions.allowDuplicates = originalAllowDuplicates;
+    };
+
+    const retryWithoutStateOnRequestTooLarge = originalFn => {
+      return (...captureArguments) => {
+        const originalTransport = Raven._globalOptions.transport;
+        Raven.setTransport(opts => {
+          Raven.setTransport(originalTransport);
+          opts.onError = error => {
+            if (error.request && error.request.status === 413) {
+              // Retry request without state after "413 request too large" error
+              retryCaptureWithoutReduxState(() => {
+                originalFn.apply(Raven, captureArguments);
+              });
+            }
+          };
+          (originalTransport || Raven._makeRequest).call(Raven, opts);
+        });
+        originalFn.apply(Raven, captureArguments);
+      };
+    };
+
+    Raven.captureException = retryWithoutStateOnRequestTooLarge(
+      Raven.captureException
+    );
+    Raven.captureMessage = retryWithoutStateOnRequestTooLarge(
+      Raven.captureMessage
+    );
+
     return next => action => {
       // Log the action taken to Raven so that we have narrative context in our
       // error report.

--- a/index.test.js
+++ b/index.test.js
@@ -2,9 +2,9 @@ const Raven = require("raven-js");
 const createRavenMiddleware = require("./index");
 const { createStore, applyMiddleware } = require("redux");
 
-Raven.config("https://5d5bf17b1bed4afc9103b5a09634775e@sentry.io/146969", {
-  allowDuplicates: true
-}).install();
+Raven.config(
+  "https://5d5bf17b1bed4afc9103b5a09634775e@sentry.io/146969"
+).install();
 
 const reducer = (previousState = { value: 0 }, action) => {
   switch (action.type) {
@@ -32,7 +32,7 @@ describe("raven-for-redux", () => {
     Raven.setDataCallback(undefined);
     Raven.setBreadcrumbCallback(undefined);
     Raven.setUserContext(undefined);
-
+    Raven._globalOptions.allowDuplicates = true;
     Raven._breadcrumbs = [];
     Raven._globalContext = {};
   });
@@ -185,6 +185,32 @@ describe("raven-for-redux", () => {
       expect(context.mockTransport.mock.calls[0][0].data.user).toEqual(
         userData
       );
+    });
+
+    ["captureException", "captureMessage"].forEach(fnName => {
+      it(`retries ${fnName} without any state if Sentry returns 413 request too large`, () => {
+        context.mockTransport.mockImplementationOnce(options => {
+          options.onError({ request: { status: 413 } });
+        });
+        // allowDuplicates is set to true inside our handler and reset afterwards
+        Raven._globalOptions.allowDuplicates = null;
+        Raven[fnName].call(Raven, new Error("Crash!"));
+
+        // Ensure transport and allowDuplicates have been reset
+        expect(Raven._globalOptions.transport).toEqual(context.mockTransport);
+        expect(Raven._globalOptions.allowDuplicates).toEqual(null);
+        expect(context.mockTransport).toHaveBeenCalledTimes(2);
+        const { extra } = context.mockTransport.mock.calls[0][0].data;
+        expect(extra).toMatchObject({
+          state: { value: 0 },
+          lastAction: undefined
+        });
+        const { extra: extra2 } = context.mockTransport.mock.calls[1][0].data;
+        expect(extra2).toMatchObject({
+          state: "Failed to submit state to Sentry: 413 request too large.",
+          lastAction: undefined
+        });
+      });
     });
   });
   describe("with all the options enabled", () => {


### PR DESCRIPTION
Related: #42

This change ensures that all exceptions are reported, even if they don't include any state. In my own app, I'm also going to add some logic that removes the redux-undo state and only sends the current state.

Another solution would be to use the [pako](https://github.com/nodeca/pako) library to gzip the whole request, then send the data with a `Content-Encoding: gzip` header. Apparently the other Sentry clients do this (e.g. Ruby, Python), and since my state had a ton of repeated data due to the undo history, I was able to compress 220 KB down to 5 KB. I'm going to try this next and see if Sentry will accept the request.

Actually, I just realized that it would be much better to just intercept the request before it is sent, and check that the request body length is less than 204800. I think that would be a better idea - We can just do `stringify(opts.data)` in the transport and check the length. I'm just not sure if the "maximum payload size" of 200kB also includes request headers. For my test requests, the headers added 527B. So it might be good to give a few KB of leeway and just set the limit at 200000. And even if we detect the limit and bail out early, I think it's still a good idea to keep the retry logic for the 413 response, because it might change in the future.

Anyway, I'm going to keep working on this, but wanted to submit now to get some feedback. Thanks!