### PR TITLE
Add breadcrumbMessageFromAction option to handle a message of breadcrumb

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ While the default configuration should work for most use cases, Raven for Redux
 can be configured by providing an options object with any of the following
 optional keys.
 
+#### `breadcrumbMessageFromAction` _(Function)_
+
+Default: `action => action.type`
+
+`breadcrumbMessageFromAction` allows you to specify a transform function which is passed the `action` object and returns a `string` that describes a message of breadcrumb. Which will be logged to Sentry.
+
+By default, `breadcrumbMessageFromAction` will log `action.type` as a `message` of breadcrumb, but you can specify another value.
+
+Finally, be careful not to mutate your `action` within this function.
+
+See the Sentry [Breadcrumb documentation].
+
 #### `breadcrumbDataFromAction` _(Function)_
 
 Default: `action => undefined`

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ optional keys.
 
 Default: `action => action.type`
 
-`breadcrumbMessageFromAction` allows you to specify a transform function which is passed the `action` object and returns a `string` that describes a message of breadcrumb. Which will be logged to Sentry.
+`breadcrumbMessageFromAction` allows you to specify a transform function which is passed the `action` object and returns a `string` that will be used as the message of the breadcrumb.
 
-By default, `breadcrumbMessageFromAction` will log `action.type` as a `message` of breadcrumb, but you can specify another value.
+By default `breadcrumbMessageFromAction` returns `action.type`.
 
 Finally, be careful not to mutate your `action` within this function.
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 const identity = x => x;
 const getUndefined = () => {};
+const getType = action => action.type;
 const filter = () => true;
 function createRavenMiddleware(Raven, options = {}) {
   // TODO: Validate options.
   const {
     breadcrumbDataFromAction = getUndefined,
+    breadcrumbMessageFromAction = getType,
     actionTransformer = identity,
     stateTransformer = identity,
     breadcrumbCategory = "redux-action",
@@ -38,7 +40,7 @@ function createRavenMiddleware(Raven, options = {}) {
       if (filterBreadcrumbActions(action)) {
         Raven.captureBreadcrumb({
           category: breadcrumbCategory,
-          message: action.type,
+          message: breadcrumbMessageFromAction(action),
           data: breadcrumbDataFromAction(action)
         });
       }

--- a/index.test.js
+++ b/index.test.js
@@ -200,6 +200,9 @@ describe("raven-for-redux", () => {
       context.breadcrumbDataFromAction = jest.fn(action => ({
         extra: action.extra
       }));
+      context.breadcrumbMessageFromAction = jest.fn(
+        action => `transformed action ${action.type}`
+      );
       context.filterBreadcrumbActions = action => {
         return action.type !== "UNINTERESTING_ACTION";
       };
@@ -211,6 +214,7 @@ describe("raven-for-redux", () => {
             stateTransformer: context.stateTransformer,
             actionTransformer: context.actionTransformer,
             breadcrumbDataFromAction: context.breadcrumbDataFromAction,
+            breadcrumbMessageFromAction: context.breadcrumbMessageFromAction,
             filterBreadcrumbActions: context.filterBreadcrumbActions,
             getUserContext: context.getUserContext,
             getTags: context.getTags
@@ -252,7 +256,11 @@ describe("raven-for-redux", () => {
       expect(context.mockTransport).toHaveBeenCalledTimes(1);
       const { breadcrumbs } = context.mockTransport.mock.calls[0][0].data;
       expect(breadcrumbs.values.length).toBe(2);
+      expect(breadcrumbs.values[0].message).toBe(
+        "transformed action INCREMENT"
+      );
       expect(breadcrumbs.values[0].data).toMatchObject({ extra: "FOO" });
+      expect(breadcrumbs.values[1].message).toBe("transformed action THROW");
       expect(breadcrumbs.values[1].data).toMatchObject({ extra: "BAR" });
     });
     it("transforms the user context on data callback", () => {


### PR DESCRIPTION
Hello @captbaritone !

Sometimes it's necessary to use the different message of action breadcrumb instead of `action.type`. 
In my project I implemented it, using `Raven.dataCallback` option. But I have to filter if the breadcrumb is action. It would be great if raven-for-redux have this feature. So I added `breadcrumbMessageFromAction` that allows defining a function to change a message of action. It could be very useful if we want to handle in Sentry custom actions.